### PR TITLE
Fix search panel resource title

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## [0.13.11] - 2025-06-13
+
+### Fixed
+
+- **Search Panel Resource Info Bug**
+  - ✅ Search panel now displays selected Bible resource title, version, and rights instead of static TWL info
+
+
 ## [0.13.10] - 2025-06-12
 
 ### Fixed

--- a/docs/proskomma-hooks-enhancement.md
+++ b/docs/proskomma-hooks-enhancement.md
@@ -151,6 +151,7 @@ SearchPanel.jsx (new)
   lang='en'
   abbr='TIT'
   usfm={usfmContent}
+  manifest={manifest}
   onResultClick={handleSearchResultClick}
 />
 ```

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "translation-helps",
   "homepage": "https://klappy.github.io/translation-helps/",
-  "version": "0.13.10",
+  "version": "0.13.11",
   "private": false,
   "dependencies": {
     "@emotion/react": "^11.10.5",

--- a/src-new/components/ScripturePanelRCL/ScripturePanelRCL.jsx
+++ b/src-new/components/ScripturePanelRCL/ScripturePanelRCL.jsx
@@ -374,6 +374,7 @@ export default function ScripturePanelRCL({ reference, onVerseClick }) {
             lang={languageId}
             abbr={reference.bookId ? reference.bookId.toUpperCase() : ""}
             usfm={usfmContent}
+            manifest={selectedManifest}
             onResultClick={handleVerseClick}
           />
         </div>

--- a/src-new/components/ScripturePanelRCL/SearchPanel.jsx
+++ b/src-new/components/ScripturePanelRCL/SearchPanel.jsx
@@ -13,9 +13,17 @@ import styles from "./SearchPanel.module.css";
  * @param {string} props.lang - Language code
  * @param {string} props.abbr - Book abbreviation
  * @param {string} props.usfm - USFM content
+ * @param {object} [props.manifest] - Bible resource manifest for display info
  * @param {function} props.onResultClick - Callback when a search result is clicked
- */
-export default function SearchPanel({ org, lang, abbr, usfm, onResultClick }) {
+*/
+export default function SearchPanel({
+  org,
+  lang,
+  abbr,
+  usfm,
+  manifest,
+  onResultClick,
+}) {
   const [searchTerm, setSearchTerm] = useState("");
   const [debouncedSearchTerm, setDebouncedSearchTerm] = useState("");
   const [timeoutError, setTimeoutError] = useState("");
@@ -354,15 +362,18 @@ export default function SearchPanel({ org, lang, abbr, usfm, onResultClick }) {
         <div className={styles.searchResourceInfo}>
           <div className={styles.searchResourceDetail}>
             <span className={styles.resourceIcon}>🏢</span>
-            <span>unfoldingWord</span>
+            <span>{org || "unfoldingWord"}</span>
           </div>
           <div className={styles.searchResourceDetail}>
             <span className={styles.resourceIcon}>📖</span>
-            <span>TWL v85</span>
+            <span>
+              {manifest?.dublin_core?.title || manifest?.title || ""}
+              {manifest?.version ? ` v${manifest.version}` : ""}
+            </span>
           </div>
           <div className={styles.searchResourceDetail}>
             <span className={styles.resourceIcon}>⚖️</span>
-            <span>CC BY-SA 4.0</span>
+            <span>{manifest?.dublin_core?.rights || manifest?.rights || ""}</span>
           </div>
         </div>
       </div>

--- a/src-new/components/ScripturePanelRCL/SearchPanel.test.jsx
+++ b/src-new/components/ScripturePanelRCL/SearchPanel.test.jsx
@@ -34,6 +34,10 @@ const defaultProps = {
 \\c 1
 \\v 1 Paul, a servant of God and an apostle of Jesus Christ
 \\v 2 in hope of eternal life`,
+  manifest: {
+    dublin_core: { title: "unfoldingWord Literal Text", rights: "CC BY-SA 4.0" },
+    version: "1",
+  },
   onResultClick: vi.fn(),
 };
 


### PR DESCRIPTION
## Summary
- correctly display Bible resource info in the scripture search panel
- pass manifest prop to `SearchPanel`
- document manifest prop usage
- bump version to 0.13.11

## Testing
- `npm test` *(fails: network errors)*

------
https://chatgpt.com/codex/tasks/task_b_684c288437e483329d9e653bbe439ca8