### PR TITLE
Fix translation notes intros

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## [0.13.12] - 2025-06-14
+
+### Fixed
+
+- **Book and Chapter tN Notes Missing**
+  - ✅ `tnService` now includes book-level (`front:intro`) and chapter-level (`<chapter>:intro`) notes when fetching notes for a verse
+  - ✅ Updated unit tests to cover introduction note handling
+  - ✅ Documentation updated explaining special reference rows in tN TSV files
+
+
 ## [0.13.11] - 2025-06-13
 
 ### Fixed

--- a/docs/Translation_Notes_Implementation.md
+++ b/docs/Translation_Notes_Implementation.md
@@ -104,6 +104,8 @@ GEN	1	1	abc1	1:1	בְּרֵאשִׁ֖ית	1	In the beginning	This refers to...
 GEN	1	1	def2	1:1	בָּרָ֣א	1	created	God made...
 ```
 
+Book and chapter introduction rows also appear in the TSV using special references. A book introduction uses `front:intro` while a chapter introduction uses `<chapter>:intro`. These notes apply to the entire book or chapter and are included along with verse notes when loaded by `tnService`.
+
 ### Parsing Logic
 
 ```javascript

--- a/package.json
+++ b/package.json
@@ -1,8 +1,7 @@
 {
   "name": "translation-helps",
   "homepage": "https://klappy.github.io/translation-helps/",
-  "version": "0.13.11",
-  "private": false,
+  "version": "0.13.12",
   "dependencies": {
     "@emotion/react": "^11.10.5",
     "@emotion/styled": "^11.10.5",

--- a/src-new/services/tnService.js
+++ b/src-new/services/tnService.js
@@ -71,16 +71,35 @@ export async function getNotesForVerse(
     const tsvContent = await fetchResourceFile(languageId, RESOURCE_ID, filePath, organization);
     const allNotes = parseTsv(tsvContent);
 
-    // Filter notes for the specific chapter and verse
+    // Filter notes for the specific chapter and verse along with chapter
+    // introduction and book introduction notes. Chapter intro notes have a
+    // reference like "1:intro" and book intro notes use "front:intro".
     const expectedRef = `${chapter}:${verse}`;
-    const verseNotes = allNotes.filter((note) => {
+    const verseNotes = [];
+    const chapterIntroNotes = [];
+    const bookIntroNotes = [];
+
+    allNotes.forEach((note) => {
       const parsed = parseReference(note.Reference);
-      if (!parsed) return false;
-      return `${parsed.chapter}:${parsed.verse}` === expectedRef;
+      if (!parsed) return;
+      const refString = `${parsed.chapter}:${parsed.verse}`;
+      if (refString === expectedRef) {
+        verseNotes.push(note);
+      } else if (
+        parsed.verse === "intro" &&
+        parsed.chapter.toString() === chapter.toString()
+      ) {
+        chapterIntroNotes.push(note);
+      } else if (parsed.verse === "intro" && parsed.chapter === "front") {
+        bookIntroNotes.push(note);
+      }
     });
 
+    // Combine intros first then verse notes
+    const combinedNotes = [...bookIntroNotes, ...chapterIntroNotes, ...verseNotes];
+
     // Transform to consistent format
-    return verseNotes.map((note, index) => ({
+    return combinedNotes.map((note, index) => ({
       id: index,
       text: note.Note || "",
       quote: note.Quote || "",

--- a/src-new/services/tnService.test.js
+++ b/src-new/services/tnService.test.js
@@ -29,6 +29,8 @@ describe("tnService", () => {
 
   const sampleTsv = [
     "Reference\tID\tTags\tSupportReference\tQuote\tOccurrence\tNote",
+    "front:intro\tbook-intro\t\t\t\t0\tBook introduction",
+    "1:intro\tchapter-intro\t\t\t\t0\tChapter 1 introduction",
     "1:1\tgen01-01-01\ttranslate-names\t\tGod\t1\tThis refers to the one true God.",
     "1:2\tgen01-02-01\tfigs-metaphor\tPsa 104:30\tthe Spirit of God\t1\tThis is a metaphor describing God's power.",
     "2:1\tgen02-01-01\ttranslate-ordinal\t\tthe seventh day\t1\tThis refers to the completion of creation.",
@@ -48,15 +50,18 @@ describe("tnService", () => {
         "tn_GEN.tsv",
         "unfoldingWord"
       );
-      expect(notes).toHaveLength(1);
-      expect(notes[0]).toEqual({
-        id: 0,
-        text: "This refers to the one true God.",
-        quote: "God",
-        occurrence: "1",
-        tags: "translate-names",
-        supportReference: "",
+      expect(notes).toHaveLength(3);
+      expect(notes[0]).toMatchObject({
+        reference: "front:intro",
+        text: "Book introduction",
+      });
+      expect(notes[1]).toMatchObject({
+        reference: "1:intro",
+        text: "Chapter 1 introduction",
+      });
+      expect(notes[2]).toMatchObject({
         reference: "1:1",
+        quote: "God",
       });
     });
 
@@ -76,13 +81,14 @@ describe("tnService", () => {
       expect(notes[0].reference).toBe("gen/1/1");
     });
 
-    it("returns empty array when no notes found", async () => {
+    it("returns only book intro when verse has no specific notes", async () => {
       dcsClient.fetchManifest.mockResolvedValue(mockManifest);
       dcsClient.fetchResourceFile.mockResolvedValue(sampleTsv);
 
       const notes = await getNotesForVerse("gen", "99", "99");
 
-      expect(notes).toHaveLength(0);
+      expect(notes).toHaveLength(1);
+      expect(notes[0].reference).toBe("front:intro");
     });
 
     it("throws error when book not found in manifest", async () => {
@@ -128,18 +134,33 @@ describe("tnService", () => {
         "tn_GEN.tsv",
         "unfoldingWord"
       );
-      expect(notes).toHaveLength(3);
+      expect(notes).toHaveLength(5);
 
       // Check that chapter and verse are parsed correctly
       expect(notes[0]).toMatchObject({
+        chapter: "front",
+        verse: "intro",
+        reference: "front:intro",
+      });
+      expect(notes[1]).toMatchObject({
+        chapter: "1",
+        verse: "intro",
+        reference: "1:intro",
+      });
+      expect(notes[2]).toMatchObject({
         chapter: "1",
         verse: "1",
         reference: "1:1",
       });
-      expect(notes[1]).toMatchObject({
+      expect(notes[3]).toMatchObject({
         chapter: "1",
         verse: "2",
         reference: "1:2",
+      });
+      expect(notes[4]).toMatchObject({
+        chapter: "2",
+        verse: "1",
+        reference: "2:1",
       });
     });
 


### PR DESCRIPTION
## Summary
- add support for book and chapter intro rows in `tnService`
- update unit tests to cover intro note behavior
- document intro row format in tN TSV files
- bump version to 0.13.12
- add changelog entry

## Testing
- `npx vitest run src-new/services/tnService.test.js`
- `npx vitest run` *(fails: 3 failed, 113 passed)*

------
https://chatgpt.com/codex/tasks/task_b_684c40b75cc08332aa2f645673e97303