### PR TITLE
Fix tN intro markdown rendering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## [0.13.13] - 2025-06-15
+
+### Fixed
+
+- **tN Introduction Markdown Rendering**
+  - ✅ `parseTsv` now converts literal "\\n" sequences to actual newlines
+  - ✅ Added unit test covering newline conversion
+  - ✅ Book and chapter introduction notes render correctly
+
 ## [0.13.12] - 2025-06-14
 
 ### Fixed

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "translation-helps",
   "homepage": "https://klappy.github.io/translation-helps/",
-  "version": "0.13.12",
+  "version": "0.13.13",
   "dependencies": {
     "@emotion/react": "^11.10.5",
     "@emotion/styled": "^11.10.5",

--- a/src-new/utils/parseTsv.js
+++ b/src-new/utils/parseTsv.js
@@ -16,7 +16,9 @@ export function parseTsv(text) {
     const cols = line.split('\t');
     const entry = {};
     headers.forEach((h, i) => {
-      entry[h] = cols[i] || '';
+      const value = cols[i] || '';
+      // tN TSV files encode newlines with "\n" sequences
+      entry[h] = value.replace(/\\n/g, '\n');
     });
     return entry;
   });

--- a/src-new/utils/parseTsv.test.js
+++ b/src-new/utils/parseTsv.test.js
@@ -22,4 +22,10 @@ describe('parseTsv', () => {
     expect(parseTsv('')).toEqual([]);
     expect(parseTsv('# no data')).toEqual([]);
   });
+
+  it('converts literal "\\n" sequences to newlines', () => {
+    const tsvWithNewlines = ['A\tB', '1\tline1\\nline2'].join('\n');
+    const result = parseTsv(tsvWithNewlines);
+    expect(result[0].B).toBe('line1\nline2');
+  });
 });


### PR DESCRIPTION
## Summary
- convert literal `\n` sequences to real newlines when parsing TSV
- test newline conversion in `parseTsv`
- bump package version to 0.13.13 and document change

## Testing
- `npm run lint` *(fails: ESLint couldn't find the config "react-app")*
- `npm test` *(fails: 1 test file failed)*
- `npx vitest run src-new/utils/parseTsv.test.js`

------
https://chatgpt.com/codex/tasks/task_b_684c45a03d748332b7e723dd46c5631c