### PR TITLE
Improve context performance and remove duplicate provider

### DIFF
--- a/src-new/components/MainView.jsx
+++ b/src-new/components/MainView.jsx
@@ -6,7 +6,6 @@
 import React, { useContext, useState, useRef, createContext } from "react";
 import { ReferenceContext } from "../context/ReferenceContext";
 import { ManifestsContext } from "../context/MultiManifestsContext";
-import { ResourcesProvider } from "../context/ResourcesContext";
 
 import { ScripturePanel } from "./ScripturePanel";
 import { HelpsTabs } from "./HelpsTabs";
@@ -140,8 +139,7 @@ export function MainView() {
   };
 
   return (
-    <ResourcesProvider>
-      <main data-testid='main-view' className={styles.mainView}>
+    <main data-testid='main-view' className={styles.mainView}>
         {/* Mobile Tab Navigation */}
         <div className={styles.mobileTabNav}>
           <button
@@ -185,6 +183,5 @@ export function MainView() {
           </div>
         </div>
       </main>
-    </ResourcesProvider>
   );
 }

--- a/src-new/context/ChatContext.jsx
+++ b/src-new/context/ChatContext.jsx
@@ -4,7 +4,7 @@
  * Updated to use ResourcesContext for anti-hallucination measures
  */
 
-import React, { createContext, useContext, useState, useCallback, useEffect } from "react";
+import React, { createContext, useContext, useState, useCallback, useEffect, useMemo } from "react";
 import {
   sendChatMessage,
   createMockResponse,
@@ -319,24 +319,44 @@ export function ChatProvider({ children }) {
     }
   }, [reference, conversationReference, chatHistory.length]);
 
-  const value = {
-    chatHistory,
-    isLoading,
-    error,
-    currentContext,
-    conversationReference,
-    resourceChangeNotification,
-    sendMessage,
-    clearChat,
-    removeMessage,
-    getContextInfo,
-    areResourcesReady,
-    getResourceStatus,
-    dismissResourceChangeNotification,
-    startNewConversation,
-    sessionCost,
-    getSessionCostInfo,
-  };
+  const value = useMemo(
+    () => ({
+      chatHistory,
+      isLoading,
+      error,
+      currentContext,
+      conversationReference,
+      resourceChangeNotification,
+      sendMessage,
+      clearChat,
+      removeMessage,
+      getContextInfo,
+      areResourcesReady,
+      getResourceStatus,
+      dismissResourceChangeNotification,
+      startNewConversation,
+      sessionCost,
+      getSessionCostInfo,
+    }),
+    [
+      chatHistory,
+      isLoading,
+      error,
+      currentContext,
+      conversationReference,
+      resourceChangeNotification,
+      sendMessage,
+      clearChat,
+      removeMessage,
+      getContextInfo,
+      areResourcesReady,
+      getResourceStatus,
+      dismissResourceChangeNotification,
+      startNewConversation,
+      sessionCost,
+      getSessionCostInfo,
+    ]
+  );
 
   return <ChatContext.Provider value={value}>{children}</ChatContext.Provider>;
 }

--- a/src-new/context/ManifestsContext.jsx
+++ b/src-new/context/ManifestsContext.jsx
@@ -3,7 +3,7 @@
  * Context to provide DCS manifests for resources.
  */
 
-import React, { createContext } from 'react';
+import React, { createContext, useMemo } from 'react';
 import { useManifest } from '../hooks/useManifest';
 
 export const ManifestsContext = createContext({ manifests: {} });
@@ -15,9 +15,8 @@ export const ManifestsContext = createContext({ manifests: {} });
 export function ManifestsProvider({ children, languageId, resourceId }) {
   const manifest = useManifest(languageId, resourceId);
   const manifests = resourceId ? { [resourceId]: manifest } : {};
+  const value = useMemo(() => ({ manifests }), [manifests]);
   return (
-    <ManifestsContext.Provider value={{ manifests }}>
-      {children}
-    </ManifestsContext.Provider>
+    <ManifestsContext.Provider value={value}>{children}</ManifestsContext.Provider>
   );
 }

--- a/src-new/context/MultiManifestsContext.jsx
+++ b/src-new/context/MultiManifestsContext.jsx
@@ -3,7 +3,7 @@
  * Context to provide DCS manifests for multiple resources.
  */
 
-import React, { createContext, useState, useEffect, useContext, useRef } from "react";
+import React, { createContext, useState, useEffect, useContext, useRef, useMemo } from "react";
 import { fetchManifest } from "../services/dcsClient";
 import { ReferenceContext } from "./ReferenceContext";
 import { fetchBibleResources } from "../services/catalogService";
@@ -109,9 +109,12 @@ export function MultiManifestsProvider({ children }) {
     loadManifests();
   }, [languageId, organization]);
 
+  const value = useMemo(
+    () => ({ manifests, isLoading }),
+    [manifests, isLoading]
+  );
+
   return (
-    <ManifestsContext.Provider value={{ manifests, isLoading }}>
-      {children}
-    </ManifestsContext.Provider>
+    <ManifestsContext.Provider value={value}>{children}</ManifestsContext.Provider>
   );
 }

--- a/src-new/context/ReferenceContext.jsx
+++ b/src-new/context/ReferenceContext.jsx
@@ -3,7 +3,7 @@
  * Context to track current organization, language, resource, and book/chapter/verse reference.
  */
 
-import React, { createContext, useContext, useState, useEffect } from "react";
+import React, { createContext, useContext, useState, useEffect, useMemo } from "react";
 import { DEFAULT_REFERENCE } from "../utils/defaultReference";
 import { updateQueryFromContext, contextFromQuery } from "../utils/contextHelpers";
 
@@ -117,23 +117,24 @@ export function ReferenceProvider({ children }) {
     }
   };
 
+  const value = useMemo(
+    () => ({
+      organization,
+      languageId,
+      resourceId,
+      reference,
+      setOrganization,
+      setLanguageId,
+      setResourceId,
+      setReference,
+      updateReference,
+      updateContext,
+    }),
+    [organization, languageId, resourceId, reference]
+  );
+
   return (
-    <ReferenceContext.Provider
-      value={{
-        organization,
-        languageId,
-        resourceId,
-        reference,
-        setOrganization,
-        setLanguageId,
-        setResourceId,
-        setReference,
-        updateReference,
-        updateContext,
-      }}
-    >
-      {children}
-    </ReferenceContext.Provider>
+    <ReferenceContext.Provider value={value}>{children}</ReferenceContext.Provider>
   );
 }
 

--- a/src-new/context/ResourcesContext.jsx
+++ b/src-new/context/ResourcesContext.jsx
@@ -370,48 +370,61 @@ export function ResourcesProvider({ children }) {
     };
   }, [resources, metadata, usfmLoading, error, isLoading, manifests, verse]);
 
-  const value = {
-    resources,
-    metadata,
-    manifests,
-    isLoading: isLoading || usfmLoading,
-    error,
-    getFormattedContext,
-    // Expose loading states with more detailed information
-    loadingStates: {
-      manifests: Object.keys(manifests).length === 0 && isLoading,
-      scripture: (!resources.scripture || usfmLoading) && isLoading,
-      translationNotes: resources.translationNotes.length === 0 && isLoading,
-      translationQuestions: resources.translationQuestions.length === 0 && isLoading,
-      translationWords: resources.translationWords.length === 0 && isLoading,
-      translationWordLinks: resources.translationWordLinks.length === 0 && isLoading,
-    },
-    // Add diagnostic information for debugging
-    diagnostics: {
-      manifestsAvailable: {
-        ult: !!manifests.ult,
-        tn: !!manifests.tn,
-        tq: !!manifests.tq,
-        tw: !!manifests.tw,
-        twl: !!manifests.twl,
+  const value = useMemo(
+    () => ({
+      resources,
+      metadata,
+      manifests,
+      isLoading: isLoading || usfmLoading,
+      error,
+      getFormattedContext,
+      // Expose loading states with more detailed information
+      loadingStates: {
+        manifests: Object.keys(manifests).length === 0 && isLoading,
+        scripture: (!resources.scripture || usfmLoading) && isLoading,
+        translationNotes: resources.translationNotes.length === 0 && isLoading,
+        translationQuestions: resources.translationQuestions.length === 0 && isLoading,
+        translationWords: resources.translationWords.length === 0 && isLoading,
+        translationWordLinks: resources.translationWordLinks.length === 0 && isLoading,
       },
-      resourceCounts: {
-        scripture: resources.scripture ? 1 : 0,
-        translationNotes: resources.translationNotes.length,
-        translationQuestions: resources.translationQuestions.length,
-        translationWords: resources.translationWords.length,
-        translationWordLinks: resources.translationWordLinks.length,
+      // Add diagnostic information for debugging
+      diagnostics: {
+        manifestsAvailable: {
+          ult: !!manifests.ult,
+          tn: !!manifests.tn,
+          tq: !!manifests.tq,
+          tw: !!manifests.tw,
+          twl: !!manifests.twl,
+        },
+        resourceCounts: {
+          scripture: resources.scripture ? 1 : 0,
+          translationNotes: resources.translationNotes.length,
+          translationQuestions: resources.translationQuestions.length,
+          translationWords: resources.translationWords.length,
+          translationWordLinks: resources.translationWordLinks.length,
+        },
+        currentReference: metadata
+          ? `${metadata.bookId} ${metadata.chapter}:${metadata.verse}`
+          : null,
+        usfmParsingStatus: {
+          loading: usfmLoading,
+          ready: usfmReady,
+          versesCount: scriptureVerses ? Object.keys(scriptureVerses).length : 0,
+        },
       },
-      currentReference: metadata
-        ? `${metadata.bookId} ${metadata.chapter}:${metadata.verse}`
-        : null,
-      usfmParsingStatus: {
-        loading: usfmLoading,
-        ready: usfmReady,
-        versesCount: scriptureVerses ? Object.keys(scriptureVerses).length : 0,
-      },
-    },
-  };
+    }),
+    [
+      resources,
+      metadata,
+      manifests,
+      isLoading,
+      usfmLoading,
+      error,
+      getFormattedContext,
+      scriptureVerses,
+      usfmReady,
+    ]
+  );
 
   return <ResourcesContext.Provider value={value}>{children}</ResourcesContext.Provider>;
 }


### PR DESCRIPTION
## Summary
- memoize values in reference, manifests, multimmanifests, resources and chat contexts
- remove nested `ResourcesProvider` from `MainView` to avoid duplicate resource loads

## Testing
- `npm test` *(fails: TypeError: Cannot read properties of undefined (reading 'gqlQuery'))*

------
https://chatgpt.com/codex/tasks/task_b_684c857e31708332b45391e233482f71