### PR TITLE
Fix manifest book list failure with fallback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## [0.13.15] - 2025-06-13
+
+### Fixed
+
+- **Book Manifest Loading Failure**
+  - ✅ Updated `BookStep` to use manifests from `MultiManifestsContext`
+  - ✅ Added fallback to default 66-book list when manifests fail
+  - ✅ Displayed notice when fallback list is used
+  - ✅ Documented behavior in `docs/book-list-fallback.md`
+
 ## [0.13.14] - 2025-06-13
 
 ### Fixed

--- a/docs/README.md
+++ b/docs/README.md
@@ -11,6 +11,7 @@ This directory contains developer-facing documentation for the translationHelps 
 | `lifecycle.md`                          | Describes the application startup process, context propagation, resource fetching, and offline/caching behavior. |
 | `component-map.md`                      | Lists core React components with file paths and responsibilities.                                                |
 | `Resource_Integration_Overview.md`      | Summarizes how translation resources (tN, tQ, tW, TWL, OBS, etc.) are integrated and linked.                     |
+| `book-list-fallback.md`                 | Explains dynamic book list loading and the default fallback mechanism.                                          |
 | `TWL_Integration_Documentation.md`      | Details the Translation Words Links (TWL) format and its integration.                                            |
 | `Translation_Notes_Implementation.md`   | Outlines how Translation Notes (tN) are implemented and rendered.                                                |
 | `DCS_Integration_Documentation.md`      | Explains integration with the Door43 Content Service (DCS).                                                      |

--- a/docs/book-list-fallback.md
+++ b/docs/book-list-fallback.md
@@ -1,0 +1,9 @@
+# Dynamic Book Listing and Fallback
+
+The book selector step loads available books for each Bible resource using the
+resource `manifest.yaml` from Door43. Network issues or missing manifest
+entries can cause this lookup to fail. When this happens the wizard now falls
+back to the default 66-book list so users can continue navigating.
+
+The UI displays a notice at the top of the book grid whenever the fallback list
+is in use.

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "translation-helps",
   "homepage": "https://klappy.github.io/translation-helps/",
-  "version": "0.13.14",
+  "version": "0.13.15",
   "dependencies": {
     "@emotion/react": "^11.10.5",
     "@emotion/styled": "^11.10.5",

--- a/src-new/components/NavigationWizard/NavigationWizard.module.css
+++ b/src-new/components/NavigationWizard/NavigationWizard.module.css
@@ -466,6 +466,17 @@
   margin-right: var(--spacing-3);
 }
 
+/* Informational notice */
+.notice {
+  background-color: var(--color-warning);
+  color: var(--color-dark);
+  padding: var(--spacing-3);
+  border-radius: var(--border-radius);
+  margin-bottom: var(--spacing-3);
+  font-size: var(--font-size-sm);
+  text-align: center;
+}
+
 /* Responsive design */
 @media (max-width: 768px) {
   .wizardContainer {

--- a/src-new/components/NavigationWizard/steps/BookStep.jsx
+++ b/src-new/components/NavigationWizard/steps/BookStep.jsx
@@ -3,9 +3,9 @@
  * Fourth step of the wizard: Book selection with Testament categorization
  */
 
-import React, { useState, useMemo, useEffect } from "react";
+import React, { useState, useMemo, useEffect, useContext } from "react";
 import { SearchableGrid } from "../SearchableGrid";
-import { fetchResourceManifest } from "../../../services/manifestService";
+import { ManifestsContext } from "../../../context/MultiManifestsContext";
 import styles from "../NavigationWizard.module.css";
 
 // Bible book data with testament categorization
@@ -93,21 +93,19 @@ export function BookStep({ onNext, onPrevious, onStepChange, wizardData, isDeskt
   const [manifest, setManifest] = useState(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState(null);
+  const [usingFallback, setUsingFallback] = useState(false);
+  const { manifests, isLoading: manifestsLoading } = useContext(ManifestsContext);
 
-  // Fetch available books from manifest
+  // Determine available books from manifests (with fallback to default list)
   useEffect(() => {
     let isMounted = true;
 
-    const loadAvailableBooks = async () => {
-      // Validate required parameters before attempting to fetch
+    const updateBooks = () => {
       if (!wizardData.organization || !wizardData.languageId || !wizardData.resourceId) {
         if (isMounted) {
           setLoading(false);
-          // Set helpful error message when resourceId is missing
           if (!wizardData.resourceId && wizardData.organization && wizardData.languageId) {
-            setError(
-              "Please select a Bible resource from the previous step to view available books."
-            );
+            setError("Please select a Bible resource from the previous step to view available books.");
           } else if (!wizardData.organization) {
             setError("Please select an organization from the first step.");
           } else if (!wizardData.languageId) {
@@ -116,96 +114,67 @@ export function BookStep({ onNext, onPrevious, onStepChange, wizardData, isDeskt
             setError(null);
           }
           setAvailableBooks([]);
+          setUsingFallback(false);
         }
         return;
       }
 
-      try {
+      if (manifestsLoading) {
         setLoading(true);
-        setError(null);
+        return;
+      }
 
-        // Debug logging to identify language ID corruption
-        console.log("🔍 BookStep manifest fetch parameters:");
-        console.log("  - organization:", wizardData.organization);
-        console.log("  - languageId:", wizardData.languageId);
-        console.log("  - resourceId:", wizardData.resourceId);
-        console.log("  - Full wizardData:", wizardData);
+      const manifest = manifests[wizardData.resourceId];
 
-        const manifest = await fetchResourceManifest(
-          wizardData.organization,
-          wizardData.languageId,
-          wizardData.resourceId
-        );
+      if (manifest && manifest.projects?.length) {
+        const manifestBooks = manifest.projects
+          .filter((project) => project && project.identifier)
+          .map((project) => {
+            const bookId = project.identifier.toLowerCase();
+            const fallbackBook = getAllBooks().find((b) => b.id === bookId);
 
-        if (isMounted && manifest && manifest.projects) {
-          // Store the manifest for metadata display
+            return {
+              id: bookId,
+              name: project.title || (fallbackBook ? fallbackBook.name : bookId.toUpperCase()),
+              chapters: project.chapters?.length || (fallbackBook ? fallbackBook.chapters : 1),
+              sort: project.sort || (fallbackBook ? getAllBooks().findIndex((b) => b.id === bookId) : 999),
+              categories: project.categories || [],
+              versification: project.versification,
+            };
+          })
+          .sort((a, b) => a.sort - b.sort);
+
+        if (isMounted) {
           setManifest(manifest);
-
-          // Extract book information from manifest projects
-          const manifestBooks = manifest.projects
-            .filter((project) => project && project.identifier)
-            .map((project) => {
-              const bookId = project.identifier.toLowerCase();
-              const fallbackBook = getAllBooks().find((b) => b.id === bookId);
-
-              return {
-                id: bookId,
-                name: project.title || (fallbackBook ? fallbackBook.name : bookId.toUpperCase()),
-                chapters: project.chapters?.length || (fallbackBook ? fallbackBook.chapters : 1),
-                sort:
-                  project.sort ||
-                  (fallbackBook ? getAllBooks().findIndex((b) => b.id === bookId) : 999),
-                categories: project.categories || [],
-                versification: project.versification,
-              };
-            })
-            .sort((a, b) => a.sort - b.sort);
-
           setAvailableBooks(manifestBooks);
-        } else if (isMounted) {
-          setError("No books found in the selected resource manifest.");
-          setAvailableBooks([]);
+          setUsingFallback(false);
+          setError(null);
+          setLoading(false);
         }
-      } catch (err) {
+      } else {
         if (isMounted) {
-          console.warn("Failed to load manifest books:", err);
-
-          // Provide more specific error messages
-          if (err.message.includes("404")) {
-            setError(
-              `The selected Bible resource (${wizardData.resourceId}) was not found for ${wizardData.organization}/${wizardData.languageId}. Please go back and select a different resource.`
-            );
-          } else if (err.message.includes("Failed to fetch")) {
-            setError(
-              "Unable to load book list. Please check your internet connection and try again."
-            );
-          } else {
-            setError(`Failed to load books: ${err.message}`);
-          }
-
-          setAvailableBooks([]);
-        }
-      } finally {
-        if (isMounted) {
+          setManifest(null);
+          setAvailableBooks(getAllBooks());
+          setUsingFallback(true);
+          setError("Dynamic book list unavailable. Showing default book list.");
           setLoading(false);
         }
       }
     };
 
-    loadAvailableBooks();
+    updateBooks();
 
     return () => {
       isMounted = false;
     };
-  }, [wizardData.organization, wizardData.languageId, wizardData.resourceId]);
+  }, [wizardData.organization, wizardData.languageId, wizardData.resourceId, manifests, manifestsLoading]);
 
   const handleBookSelect = (book) => {
     onStepChange(4, { bookId: book.id });
   };
 
-  // Only use books from the manifest - no fallback to hardcoded books
   const currentBooks = availableBooks || [];
-  const isUsingDynamicBooks = availableBooks !== null && availableBooks.length > 0;
+  const isUsingDynamicBooks = !usingFallback && availableBooks !== null && availableBooks.length > 0;
 
   const { oldTestamentBooks, newTestamentBooks } = useMemo(() => {
     if (isUsingDynamicBooks) {
@@ -290,6 +259,11 @@ export function BookStep({ onNext, onPrevious, onStepChange, wizardData, isDeskt
 
       {/* Content area */}
       <div className={`${styles.stepContent} ${isDesktop ? styles.desktop : ""}`}>
+        {usingFallback && (
+          <div className={styles.notice} data-testid='fallback-notice'>
+            Dynamic book list unavailable. Displaying default list.
+          </div>
+        )}
         <SearchableGrid
           items={bookItems}
           selectedItem={selectedBook}
@@ -299,7 +273,7 @@ export function BookStep({ onNext, onPrevious, onStepChange, wizardData, isDeskt
           emptyIcon='📖'
           isDesktop={isDesktop}
           isLoading={loading}
-          error={error}
+          error={usingFallback ? null : error}
           getItemKey={(item) => item.id}
           getItemTitle={(item) => item.title}
           getItemSubtitle={(item) => item.description}


### PR DESCRIPTION
## Summary
- use manifests from context in `BookStep`
- show notice and default book list when manifest book data fails
- document fallback behavior
- bump version to 0.13.15

## Testing
- `npm test` *(fails: Network error, module not found)*

------
https://chatgpt.com/codex/tasks/task_b_684cae1214088332ba5f6ea90182f8ca