### PR TITLE
Add offline cache service

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -425,7 +425,7 @@ const llmChatService = {
 const cache = {
   manifests: new Map(),    // Resource manifests
   resources: new Map(),    // Parsed resource data
-  raw: new Map()          // Raw file content
+  raw: new Map()          // Raw file content (persisted via localForage by URL)
 };
 
 // Cache key pattern

--- a/docs/Resource_Integration_Overview.md
+++ b/docs/Resource_Integration_Overview.md
@@ -117,6 +117,7 @@ const fileName = project.path.replace("./", "");
 - **Organization-Aware Keys**: `${org}:${lang}:${resource}:${reference}`
 - **Error Caching**: Failed requests cached to avoid retries
 - **Cache Clearing**: Available for testing and refresh
+- **Offline Raw Cache**: LocalForage persists raw files keyed by URL for offline reuse
 
 ## 📊 Supported Organizations
 

--- a/docs/lifecycle.md
+++ b/docs/lifecycle.md
@@ -59,6 +59,6 @@ This document describes the runtime behavior and application lifecycle of the tr
 
 ## 💾 Offline / Cache Model
 
-- Local caching is handled by IndexedDB via localForage (used for manifests and possibly TSV content)
+- Local caching is handled by IndexedDB via localForage (used for manifests, raw files cached by URL, and possibly TSV content)
 - Service worker (if enabled) may precache key assets
 - App supports offline view for already-loaded books but does not attempt to persist all resources

--- a/src-new/services/offlineCacheService.js
+++ b/src-new/services/offlineCacheService.js
@@ -1,0 +1,46 @@
+/**
+ * offlineCacheService.js
+ * Simple URL-based caching using localForage for offline support.
+ */
+import localforage from 'localforage';
+
+// Create a dedicated instance so we don't pollute global storage
+const store = localforage.createInstance({ name: 'offlineFileCache' });
+
+/**
+ * Fetch a URL and cache the response text for offline usage.
+ * @param {string} url - The resource URL.
+ * @returns {Promise<string>} The response text from cache or network.
+ */
+export async function fetchCachedFile(url) {
+  if (!url) throw new Error('URL is required');
+
+  // Check persistent cache first
+  const cached = await store.getItem(url);
+  if (cached) {
+    return cached;
+  }
+
+  const res = await fetch(url);
+  if (!res.ok) {
+    throw new Error(`Failed to fetch ${url}: ${res.status} ${res.statusText}`);
+  }
+  const text = await res.text();
+  await store.setItem(url, text);
+  return text;
+}
+
+/**
+ * Clear the offline cache.
+ * @param {string} [url] - Specific URL to remove; clears all if omitted.
+ */
+export async function clearOfflineCache(url) {
+  if (url) {
+    await store.removeItem(url);
+  } else {
+    await store.clear();
+  }
+}
+
+export default { fetchCachedFile, clearOfflineCache };
+

--- a/src-new/services/offlineCacheService.test.js
+++ b/src-new/services/offlineCacheService.test.js
@@ -1,0 +1,34 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import localforage from 'localforage';
+import { fetchCachedFile, clearOfflineCache } from './offlineCacheService.js';
+
+// Mock fetch
+global.fetch = vi.fn();
+
+describe('offlineCacheService', () => {
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    await clearOfflineCache();
+  });
+
+  it('fetches from network and caches the result', async () => {
+    fetch.mockResolvedValueOnce({ ok: true, text: async () => 'data' });
+
+    const result = await fetchCachedFile('http://example.com/file.txt');
+
+    expect(result).toBe('data');
+    expect(fetch).toHaveBeenCalledWith('http://example.com/file.txt');
+    const stored = await localforage.getItem('http://example.com/file.txt');
+    expect(stored).toBe('data');
+  });
+
+  it('returns cached data without network call', async () => {
+    await localforage.setItem('http://example.com/file.txt', 'cached');
+
+    const result = await fetchCachedFile('http://example.com/file.txt');
+
+    expect(result).toBe('cached');
+    expect(fetch).not.toHaveBeenCalled();
+  });
+});
+


### PR DESCRIPTION
## Summary
- add simple LocalForage-based cache keyed by URL
- document offline raw cache in lifecycle and resource overview
- mention persistence in architecture
- tests for the new service

## Testing
- `npm test --silent` *(fails: MODULE_NOT_FOUND & network errors)*

------
https://chatgpt.com/codex/tasks/task_b_684c8684fdf08332816b97ecf631d30b