### PR TITLE
Add reference history display in chat

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## [2.4.0] - 2025-06-16
+
+### Added
+
+- **Reference History Bubble in LLM Chat**
+  - ✅ Displays list of verse references used during conversation
+  - ✅ Updated ChatContext to track `referenceHistory`
+  - ✅ Expanded context indicator UI to show history
+  - ✅ Documentation and version updated
+
 ## [2.3.0] - 2025-06-15
 
 ### Added

--- a/docs/llm-chat-feature.md
+++ b/docs/llm-chat-feature.md
@@ -1,5 +1,20 @@
 # LLM Chat Feature Documentation
 
+## Version 2.4.0 Update (2025-06-16) - Reference History Bubble
+
+The chat header now shows a running list of references used during the conversation.
+As you navigate between verses, the badge expands to include each new reference
+so you can easily track which passages have been discussed.
+
+### Implementation Highlights
+
+- `ChatContext` now maintains a `referenceHistory` array tracking each reference
+  used in order.
+- `LLMChatPanel` renders this list in the context indicator badge, joined by
+  arrows (e.g., `TIT 1:1 → GEN 1:2`).
+- Clearing the chat resets the history so a fresh conversation starts clean.
+
+
 ## Version 2.3.0 Update (2025-06-15) - Seamless Context Slipstreaming
 
 ### 🚀 **Revolutionary Chat Experience Enhancement**

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "translation-helps",
   "homepage": "https://klappy.github.io/translation-helps/",
-  "version": "2.3.0",
+  "version": "2.4.0",
   "dependencies": {
     "@emotion/react": "^11.10.5",
     "@emotion/styled": "^11.10.5",

--- a/src/components/LLMChatPanel.jsx
+++ b/src/components/LLMChatPanel.jsx
@@ -24,6 +24,7 @@ export function LLMChatPanel({ reference }) {
     areResourcesReady,
     getResourceStatus,
     resourceChangeNotification,
+    referenceHistory,
     dismissResourceChangeNotification,
     startNewConversation,
     sessionCost,
@@ -173,6 +174,10 @@ Model: ${message.costEstimate.model}`}
   };
 
   const contextInfo = getContextInfo();
+  const referenceDisplay =
+    referenceHistory && referenceHistory.length > 0
+      ? referenceHistory.join(' \u2192 ')
+      : contextInfo?.reference;
 
   return (
     <div className={styles.chatPanel} data-testid='llm-chat-panel'>
@@ -187,7 +192,7 @@ Model: ${message.costEstimate.model}`}
             <div className={styles.contextIndicator} title='Current context loaded'>
               <span className={styles.contextIcon}>📚</span>
               <span className={styles.contextText}>
-                {contextInfo.reference} ({contextInfo.resourceCount} resources)
+                {referenceDisplay} ({contextInfo.resourceCount} resources)
               </span>
             </div>
           )}

--- a/src/context/ChatContext.jsx
+++ b/src/context/ChatContext.jsx
@@ -29,6 +29,8 @@ export function ChatProvider({ children }) {
   const [error, setError] = useState(null);
   const [currentContext, setCurrentContext] = useState(null);
   const [conversationReference, setConversationReference] = useState(null);
+  // Keep a running history of references used during the conversation
+  const [referenceHistory, setReferenceHistory] = useState([]);
   const [resourceChangeNotification, setResourceChangeNotification] = useState(null);
   const [sessionCost, setSessionCost] = useState({
     total: 0,
@@ -36,6 +38,20 @@ export function ChatProvider({ children }) {
     totalTokens: { input: 0, output: 0 },
     messages: [], // Store individual message costs
   });
+
+  /**
+   * Updates the active reference and records it in the history array
+   */
+  const updateConversationReference = useCallback((newRef) => {
+    setConversationReference((prevRef) => {
+      if (prevRef !== newRef) {
+        setReferenceHistory((hist) =>
+          hist[hist.length - 1] !== newRef ? [...hist, newRef] : hist
+        );
+      }
+      return newRef;
+    });
+  }, []);
 
   // Get current reference from ReferenceContext
   const referenceContext = useReferenceContext();
@@ -150,7 +166,7 @@ export function ChatProvider({ children }) {
         }
 
         // Update conversation reference and context
-        setConversationReference(currentRef);
+        updateConversationReference(currentRef);
         setCurrentContext(context);
 
         // Determine if we should use mock response
@@ -255,6 +271,7 @@ export function ChatProvider({ children }) {
     setCurrentContext(null);
     setError(null);
     setConversationReference(null);
+    setReferenceHistory([]);
     setResourceChangeNotification(null);
     setSessionCost({
       total: 0,
@@ -334,11 +351,11 @@ export function ChatProvider({ children }) {
       const currentRef = `${reference.bookId} ${reference.chapter}:${reference.verse}`;
       if (conversationReference !== currentRef) {
         // Just update the conversation reference silently - no blocking notifications
-        setConversationReference(currentRef);
+        updateConversationReference(currentRef);
         console.log(`[ChatContext] Context updated from ${conversationReference} to ${currentRef}`);
       }
     }
-  }, [reference, conversationReference, chatHistory.length]);
+  }, [reference, conversationReference, chatHistory.length, updateConversationReference]);
 
   const value = {
     chatHistory,
@@ -346,6 +363,7 @@ export function ChatProvider({ children }) {
     error,
     currentContext,
     conversationReference,
+    referenceHistory,
     resourceChangeNotification,
     sendMessage,
     clearChat,


### PR DESCRIPTION
## Summary
- track referenceHistory in ChatContext
- show history in chat badge
- document reference history feature
- bump version to 2.4.0 and update changelog

## Testing
- `npm test` *(fails: Cancelling test run)*

------
https://chatgpt.com/codex/tasks/task_b_684e6b09eaf48332bc8765180692ae92